### PR TITLE
Fix manufacturer code matching (string vs numeric 304)

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@
 // body: JSON.stringify({value: value})
 
 
+
 // const debug = require("debug")("signalk-empirbusnxt") Debug handled by Signal K Server
 const path = require('path')
 const Concentrate2 = require("concentrate2");
@@ -80,6 +81,7 @@ const Int64LE = require('int64-buffer').Int64LE
 const _ = require('lodash')
 
 const manufacturerCode = "Empir Bus" // According to http://www.nmea.org/Assets/20140409%20nmea%202000%20registration%20list.pdf
+const manufacturerCodeNumeric = 304  // Newer EmpirBus Devices (MCU v2 Differences)
 const pgnApiNumber = 65280 // NMEA2000 Proprietary PGN 65280 – Single Frame, Destination Address Global
 const pgnIsoNumber = 059904 // NMEA 2000 ISO request PGN 059904 - Single Frame, Destination Address Global
 const pgnAddress = 255 // Device to send to, 255 = global address, used for sending addressed messages to all nodes
@@ -120,7 +122,13 @@ module.exports = function(app) {
 
   plugin.listener = (msg) => {
 
-    if ( msg.pgn == pgnApiNumber && msg.fields['Manufacturer Code'] == manufacturerCode ) {
+    if (        // adding Numerical Code identifier
+  msg.pgn == pgnApiNumber &&
+    (
+    msg.fields['Manufacturer Code'] == manufacturerCode ||
+    msg.fields['Manufacturer Code'] == manufacturerCodeNumeric
+    )
+  ) {     
       var state = readData(msg.fields['Data'])
 
       state.instance--;    // "Receive from network" instance = "Transmit to network" instance + 1


### PR DESCRIPTION
Newer EmpirBus devices report Manufacturer Code as 304; accept both forms to process PGN 65280.

EmpirBus devices (e.g., MCUv2) report Manufacturer Code as numeric 304

Plugin currently checks for string "Empir Bus" only

This change accepts both string and numeric codes so PGN 65280 is parsed and deltas are created